### PR TITLE
feat: Implement custom staff sorting by position

### DIFF
--- a/src/hooks/useSupabaseStaffData.ts
+++ b/src/hooks/useSupabaseStaffData.ts
@@ -16,6 +16,7 @@ export interface StaffMember {
   image: string;
   description: string;
   category: string;
+  display_order?: number;
 }
 
 export const useSupabaseStaffData = (category: string) => {
@@ -33,7 +34,7 @@ export const useSupabaseStaffData = (category: string) => {
         .from('staff')
         .select('*')
         .eq('category', category)
-        .order('name');
+        .order('display_order', { ascending: true });
 
       if (error) {
         console.error('Error fetching staff:', error);


### PR DESCRIPTION
This commit introduces custom sorting for staff members based on a new 'display_order' field.

Key changes:
- Modified the `useSupabaseStaffData` hook to fetch staff ordered by the `display_order` column in ascending order, instead of by 'name'.
- Updated the `StaffMember` interface in `useSupabaseStaffData.ts` to include the optional `display_order: number;` field.
- Reviewed `StudentPrefects.tsx` and confirmed its existing filtering logic is compatible with the new sorting mechanism, where `display_order` will sort individuals within the filtered groups.

To enable this feature, you must:
1. Add a numeric `display_order` column to your 'staff' table in Supabase.
2. Populate this column with appropriate integer values to define the desired sorting hierarchy for each staff category. Lower numbers will appear first.

This change allows for granular control over staff member display order on pages like Primary Teachers, Senior Teachers, Head Staff, Head Teachers, and Student Prefects, aligning with specific positional hierarchies rather than alphabetical order.